### PR TITLE
Added @Repository annotation to Repository Beans 

### DIFF
--- a/src/main/java/guru/springframework/spring5webapp/repositories/AuthorRepository.java
+++ b/src/main/java/guru/springframework/spring5webapp/repositories/AuthorRepository.java
@@ -2,9 +2,11 @@ package guru.springframework.spring5webapp.repositories;
 
 import guru.springframework.spring5webapp.model.Author;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 /**
  * Created by jt on 5/16/17.
  */
+@Repository
 public interface AuthorRepository extends CrudRepository<Author, Long> {
 }

--- a/src/main/java/guru/springframework/spring5webapp/repositories/BookRepository.java
+++ b/src/main/java/guru/springframework/spring5webapp/repositories/BookRepository.java
@@ -2,9 +2,11 @@ package guru.springframework.spring5webapp.repositories;
 
 import guru.springframework.spring5webapp.model.Book;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 /**
  * Created by jt on 5/16/17.
  */
+@Repository
 public interface BookRepository extends CrudRepository<Book, Long> {
 }


### PR DESCRIPTION
If the "(at)Repository" annotation is missing on the Repository interfaces, IntelliJ will complain about not being able to autowire them.

![image](https://user-images.githubusercontent.com/28890586/41824558-6aaaff9e-7812-11e8-8c20-9bf9f4b01494.png)

NOTE: This is my first ever GitHub pull-request ... so here's hoping I get it right :)